### PR TITLE
Fix missing standard warning in cflags (set to use C99)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
 ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
 LDFLAGS += -fPIC -shared  -dynamiclib
-CFLAGS ?= -fPIC -O2 -Wall -Wextra -Wno-unused-parameter
+CFLAGS ?= -fPIC -O2 -Wall -Wextra -Wno-unused-parameter -std=c99
 
 ifeq ($(CROSSCOMPILE),)
 ifeq ($(shell uname),Darwin)


### PR DESCRIPTION
This tells compiler to use C99 standard, required to fix a bad error out code in gcc (Debian 4.9.2-10) 4.9.2.